### PR TITLE
fix: resolve nodepools creation issue with custom/data AMI ID handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Updated `main.tf` to remove `try` function for `ec2nodeclass.amiId` to handle `null` values and fallback to `local.eks_amd_ami_id`.
-- Added condition to manage and allow the option to use a given EKS custom AMI ID for the node pool.
+- Update `main.tf` to remove `try` function for `ec2nodeclass.amiId` to handle `null` values and fallback to `local.eks_amd_ami_id`.
+- Update `NodeGroup` for Reference `EC2NodeClass`
 
 ## [1.0.2] - 2024-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.3] - 2024-11-15
+
+### Changed
+
+- Updated `main.tf` to remove `try` function for `ec2nodeclass.amiId` to handle `null` values and fallback to `local.eks_amd_ami_id`.
+- Added condition to manage and allow the option to use a given EKS custom AMI ID for the node pool.
+
 ## [1.0.2] - 2024-11-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This Terraform module creates Karpenter node pools and associated resources usin
 ### Usage
 
 ```hcl
-module "karpenter_node_pools" {
-  source = "karpenter"
+module "karpenter" {
+  source  = "govind0229/karpenter/aws"
 
-  cluster_name                        = "your-cluster-name"
+
+  cluster_name                        = "cluster1"
   cluster_endpoint                    = "https://xyz"
   cluster_openid_connect_provider_arn = "xyz"
   cluster_openid_connect_provider_url = "https://xyz"
@@ -29,8 +30,8 @@ module "karpenter_node_pools" {
   node_pools = [
     {
       name                  = "karpenter-nodepool-1"
-      eks_custom_ami_id     = ""  # This is being manually specified eks nodes ami id
-      subnet_discovery_tag  = "cluster1"
+      eks_custom_ami_id     = ""                          # This is being manually specified eks nodes ami id
+      subnet_discovery_tag  = "cluster1"                  # The cluster name you used to tag the worker subnets.
       tags = {
         environment_name          = "dev"
         instanceName              = "Karpenter-cluster1"
@@ -40,8 +41,8 @@ module "karpenter_node_pools" {
     },
     # {
     #  name                  = "karpenter-nodepool-2"
-    #  eks_custom_ami_id     = ""  # This is being manually specified eks nodes ami id
-    #  subnet_discovery_tag  = "cluster2"
+    #  eks_custom_ami_id     = ""                           # This is being manually specified eks nodes ami id
+    #  subnet_discovery_tag  = "cluster1"                   # The cluster name you used to tag the worker subnets.
     #  tags = {
     #    environment_name         = "dev"
     #    instanceName             = "Karpenter-cluster2"
@@ -53,6 +54,14 @@ module "karpenter_node_pools" {
 }
 ```
 
+#### Subnet Tagging
+For `ec2nodeclass`, you need to tag your `subnets` using the following `key:value` pair. The value clould be the `cluster name` for identification:
+
+```hcl
+tag_key   = "karpenter.sh/discovery"
+tag_value = "Cluster_name"
+```
+
 ##### Outputs
 
 This module does not have any outputs.
@@ -61,3 +70,8 @@ This module does not have any outputs.
 
 - `aws` - The AWS provider.
 - `helm` - The Helm provider.
+
+### Requirements
+- Terraform >= 0.14.0
+- AWS provider >= 3.0
+- Helm provider >= 2.0

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,6 @@
 // Create a local variable to store the AMI query
 locals {
     eks_ami_query = var.eks_ami_release_version != null ? "${split(".", var.eks_ami_release_version)[0]}.${split(".", var.eks_ami_release_version)[1]}-v${split("-", var.eks_ami_release_version)[1]}" : null
+    eks_amd_ami_id = data.aws_ami.eks_ami_query[0].id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,12 @@ resource "helm_release" "karpenter_nodepool" {
 
   set {
     name  = "ec2nodeclass.amiId"
-    value = try(each.value.eks_custom_ami_id, data.aws_ami.eks_ami_query[0].id)
+    value = each.value.eks_custom_ami_id != "" ? each.value.eks_custom_ami_id : local.eks_amd_ami_id
+  }
+
+  set {
+    name  = "nodepool.nodeClassRef.name"
+    value = each.value.name
   }
 
   set {


### PR DESCRIPTION
### Changed

- Update `main.tf` to remove `try` function for `ec2nodeclass.amiId` to handle `null` values and fallback to `local.eks_amd_ami_id`.
- Update `NodeGroup` for Reference `EC2NodeClass`